### PR TITLE
Improve bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -2,4 +2,13 @@
 
 set -e
 
+if ! command -v brew > /dev/null; then
+  echo
+  echo "Install homebrew: see https://brew.sh"
+  echo
+  exit 1
+fi
+
+brew install coreutils
+
 npm install


### PR DESCRIPTION
Setup previously required coreutils implicitly

* Check for brew. If not found, echo out
* Install coreutils using brew