### PR TITLE
Use `async` / `await` syntax in asynchronous tests

### DIFF
--- a/test/requests/messages-test.js
+++ b/test/requests/messages-test.js
@@ -15,45 +15,39 @@ describe("/messages", () => {
   });
 
   describe("POST", () => {
-    it("creates a new message", (done) => {
+    it("creates a new message", async () => {
       const author = "Inquisitive User";
       const message = "Why Test?";
 
-      request(server).
+      const { text } = await request(server).
         post("/messages").
-        send({ author, message }).
-        then(({ text }) => {
-          assert.include(text, author);
-          assert.include(text, message);
-          done();
-        });
+        send({ author, message });
+
+      assert.include(text, author);
+      assert.include(text, message);
     });
 
     describe("when the author is blank", () => {
-      it("renders an error message", (done) => {
+      it("renders an error message", async () => {
         const message = "Why Test?";
 
-        request(server).
+        const { text } = await request(server).
           post("/messages").
-          send({ message }).
-          then(({ text }) => {
-            assert.include(text, "Invalid value");
-            done();
-          });
+          send({ message });
+
+        assert.include(text, "Invalid value");
       });
     });
 
     describe("when the message is blank", () => {
-      it("displays an error message", (done) => {
+      it("displays an error message", async () => {
         const author = "A User";
 
-        request(server).
+        const { text } = await request(server).
           post("/messages").
-          send({ author }).
-          then(({ text }) => {
-            assert.include(text, "Invalid value");
-            done();
-          });
+          send({ author });
+
+        assert.include(text, "Invalid value");
       });
     });
   });


### PR DESCRIPTION
In order to better demonstrate the four phases of tests, utilize newer
versions' of ES support for `async` and `await` to replace callbacks and
promises with synchronous-looking code.