### PR TITLE
setup-mongo

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -9,9 +9,32 @@ if ! command -v brew > /dev/null; then
   exit 1
 fi
 
-brew install coreutils
-brew install selenium-server-standalone
+packages="
+  coreutils
+  selenium-server-standalone
+  mongodb
+"
+
+for package in $packages; do
+  brew install $package || true
+done
 
 brew cask install java
+
+cat << EOF
+
+-----
+
+To have launchd start mongodb now and restart at login:
+
+  $ brew services start mongodb
+
+Or, if you don't want/need a background service you can just run:
+
+  $ mongod --config /usr/local/etc/mongod.conf
+
+-----
+
+EOF
 
 npm install

--- a/test/requests/messages-test.js
+++ b/test/requests/messages-test.js
@@ -5,20 +5,18 @@ const port = process.env.EXPRESS_PORT || 3000;
 const database = require("../../database");
 const Message = require("../../models/message");
 
-const clearDB = (done) => {
-  database.connection.db.dropDatabase(done);
-};
-
 describe("/messages", () => {
   let server;
 
-  beforeEach((done) => {
-    server = app.listen(port, () => {
-      clearDB(done);
-    });
+  beforeEach("Start server", (done) => {
+    server = app.listen(port, done);
   });
 
-  afterEach((done) => {
+  afterEach("Drop database", (done) => {
+    database.connection.db.dropDatabase(done);
+  });
+
+  afterEach("Shutdown server", (done) => {
     server.close(done);
   });
 


### PR DESCRIPTION
# Install and Setup Mongodb

This commit extends `bin/setup` to install and start a MongoDB server.

Additionally, this commit restructures our end-to-end tests by
separating server start-up from database rollback.

Modify `beforeEach` and `afterEach` hooks to describe their intent to
improve failure reporting.