### PR TITLE
Switch from `chrome` to `firefox` for e2e tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       # specify the version you desire here
       - image: circleci/node:7.10
       - image: circleci/openjdk:9
-      - image: selenium/standalone-chrome:3.1.0
+      - image: selenium/standalone-firefox:3.6.0
       - image: circleci/mongo:3.4.4
 
     working_directory: ~/repo

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -12,10 +12,10 @@ exports.config = {
   framework: 'mocha',
   reporters: ['dot'],
   capabilities: [{
-    browserName: 'chrome',
+    browserName: 'firefox',
   }],
-  chromeOptions: {
-    args: ['--headless'],
+  firefoxOptions: {
+    args: ['-headless'],
   },
   services: ['selenium-standalone'],
 


### PR DESCRIPTION
Use the `standalone-firefox` image on CircleCI.

Replace `"chrome"` and `chromeOptions` in the WebDriverIO configuration
with Firefox counterparts.