### PR TITLE
Change server test verification

### DIFF
--- a/routes/messages.js
+++ b/routes/messages.js
@@ -16,6 +16,8 @@ router.post(
 
     if (errors.isEmpty()) {
       await Message.create({author, message});
+    } else {
+      res.status(400);
     }
 
     const messages = await Message.find({});

--- a/test/routes/messages-test.js
+++ b/test/routes/messages-test.js
@@ -27,25 +27,25 @@ describe('/messages', () => {
       const author = 'Inquisitive User';
       const message = 'Why Test?';
 
-      const {text} = await request(server)
-        .post('/messages')
-        .send({author, message});
+      const response = await request(server).
+        post('/messages').
+        send({author, message});
 
-      assert.include(text, author);
-      assert.include(text, message);
+      assert.equal(response.status, 200);
+      assert.ok(await Message.findOne({message, author}), 'Creates a Message record');
     });
 
     describe('when the author is blank', () => {
       it('renders an error message', async () => {
         const message = 'Why Test?';
 
-        const {text} = await request(server)
+        const response = await request(server)
           .post('/messages')
           .send({message});
 
-        const messages = await Message.find({});
-        assert.include(text, 'Invalid value');
-        assert.empty(messages);
+        assert.equal(response.status, 400);
+        assert.include(response.text, 'Invalid value');
+        assert.equal((await Message.find({})).length, 0, 'did not save the Message');
       });
     });
 
@@ -53,13 +53,13 @@ describe('/messages', () => {
       it('displays an error message', async () => {
         const author = 'A User';
 
-        const {text} = await request(server)
+        const response = await request(server)
           .post('/messages')
           .send({author});
 
-        const messages = await Message.find({});
-        assert.include(text, 'Invalid value');
-        assert.empty(messages);
+        assert.equal(response.status, 400);
+        assert.include(response.text, 'Invalid value');
+        assert.equal((await Message.find({})).length, 0, 'did not save the Message');
       });
     });
   });


### PR DESCRIPTION
Our Feature tests give us confidence that the contents of a message and
its author are rendered onto the page.

This commit modifies a feature test to verify that a `Message` record is
created as a side-effect.

Additionally, we assert that invalid parameters result in a response
with a [422 HTTP Status][docs].

[docs]: https://httpstatuses.com/422