### PR TITLE
Route test asserts redirection after creation

### DIFF
--- a/routes/messages.js
+++ b/routes/messages.js
@@ -16,16 +16,15 @@ router.post(
 
     if (errors.isEmpty()) {
       await Message.create({author, message});
+      res.redirect('/');
     } else {
       res.status(400);
+
+      res.render('index', {
+        errors: errors.mapped(),
+        messages: await Message.find({}),
+      });
     }
-
-    const messages = await Message.find({});
-
-    res.render('index', {
-      errors: errors.mapped(),
-      messages: messages,
-    });
   }
 );
 

--- a/test/routes/messages-test.js
+++ b/test/routes/messages-test.js
@@ -28,18 +28,29 @@ describe('/messages', () => {
   });
 
   describe('POST', () => {
-    it('creates a new message', async () => {
-      const author = 'Inquisitive User';
-      const message = 'Why Test?';
+    describe('when the Message is valid', () => {
+      it('creates a new message', async () => {
+        const author = 'Inquisitive User';
+        const message = 'Why Test?';
 
-      const response = await request(server).
-        post('/messages').
-        send({author, message});
+        const response = await request(server).
+          post('/messages').
+          send({author, message});
 
-      assert.equal(response.status, 200);
-      assert.include(parseTextFromHTML(response.text, '#messages'), author);
-      assert.include(parseTextFromHTML(response.text, '#messages'), message);
-      assert.ok(await Message.findOne({message, author}), 'Creates a Message record');
+        assert.ok(await Message.findOne({message, author}), 'Creates a Message record');
+      });
+
+      it('redirects to the index', async () => {
+        const author = 'Inquisitive User';
+        const message = 'Why Test?';
+
+        const response = await request(server).
+          post('/messages').
+          send({author, message});
+
+        assert.equal(response.status, 302);
+        assert.equal(response.headers.location, '/');
+      });
     });
 
     describe('when the author is blank', () => {


### PR DESCRIPTION
Instead of duplicating coverage provided at the feature level, the test
covering `POST /messages` asserts that the response will redirect to the
`index` route, mounted to `GET /`.

Support for this change was test-driven by splitting the route test's
Happy Path into two separate `it` blocks, with fewer assertions in each.

We could use this change to draw learner attention to the fact that
there are two _separate_ side-effects we're asserting here, which can
improve each test's _readability_ and our suite's _completeness_.