### PR TITLE
Validate with Mongoose

### DIFF
--- a/models/message.js
+++ b/models/message.js
@@ -3,9 +3,11 @@ const mongoose = require('mongoose');
 module.exports = mongoose.model('Message', mongoose.Schema({
   author: {
     type: String,
+    required: true,
   },
 
   message: {
     type: String,
+    required: true,
   },
 }));

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,42 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@types/express": {
-      "version": "4.0.37",
-      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.0.37.tgz",
-      "integrity": "sha512-tIULTLzQpFFs5/PKnFIAFOsXQxss76glppbVKR3/jddPK26SBsD5HF5grn5G2jOGtpRWSBvYmDYoduVv+3wOXg==",
-      "requires": {
-        "@types/express-serve-static-core": "4.0.53",
-        "@types/serve-static": "1.7.32"
-      }
-    },
-    "@types/express-serve-static-core": {
-      "version": "4.0.53",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.53.tgz",
-      "integrity": "sha512-zaGeOpEYp5G2EhjaUFdVwysDrfEYc6Q6iPhd3Kl4ip30x0tvVv7SuJvY3yzCUSuFlzAG8N5KsyY6BJg93/cn+Q==",
-      "requires": {
-        "@types/node": "8.0.31"
-      }
-    },
-    "@types/mime": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
-      "integrity": "sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA=="
-    },
-    "@types/node": {
-      "version": "8.0.31",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.31.tgz",
-      "integrity": "sha512-R+LdMJHJQwRd/Ca0Nr5KnwbSWHxTD3DWz4ivqoPeNH+YPcuirMWK+Ti9Mx32jOecmPhHOCd+6CefU5e1eVq2Ew=="
-    },
-    "@types/serve-static": {
-      "version": "1.7.32",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.7.32.tgz",
-      "integrity": "sha512-WpI0g7M1FiOmJ/a97Qrjafq2I938tjAZ3hZr9O7sXyA6oUhH3bqUNZIt7r1KZg8TQAKxcvxt6JjQ5XuLfIBFvg==",
-      "requires": {
-        "@types/express-serve-static-core": "4.0.53",
-        "@types/mime": "2.0.0"
-      }
-    },
     "abab": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -871,23 +835,6 @@
         "handlebars": "4.0.10",
         "object.assign": "4.0.4",
         "promise": "7.3.1"
-      }
-    },
-    "express-validator": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/express-validator/-/express-validator-4.2.1.tgz",
-      "integrity": "sha512-c2oiv3THmHdbDYV8qSXWq/yB17Gt3KopsseRqxKsn3s5xUz0G0E1hSQXeUjgL2+H9OAAGb6JMgc1Y9+7LO5XHg==",
-      "requires": {
-        "@types/express": "4.0.37",
-        "lodash": "4.17.4",
-        "validator": "8.2.0"
-      },
-      "dependencies": {
-        "validator": {
-          "version": "8.2.0",
-          "resolved": "https://registry.npmjs.org/validator/-/validator-8.2.0.tgz",
-          "integrity": "sha512-Yw5wW34fSv5spzTXNkokD6S6/Oq92d8q/t14TqsS3fAiA1RYnxSFSIZ+CY3n6PGGRCq5HhJTSepQvFUS2QUDxA=="
-        }
       }
     },
     "extend": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "debug": "~2.6.3",
     "express": "~4.15.2",
     "express-handlebars": "^3.0.0",
-    "express-validator": "^4.2.1",
     "jsdom": "9.12.0",
     "mongoose": "^4.11.13",
     "morgan": "~1.8.1",

--- a/routes/messages.js
+++ b/routes/messages.js
@@ -1,31 +1,25 @@
-const {body, validationResult} = require('express-validator/check');
 const express = require('express');
 const router = express.Router();
 
 const Message = require('../models/message');
 
-router.post(
-  '/',
-  [
-    body('author').not().isEmpty(),
-    body('message').not().isEmpty(),
-  ],
-  async (req, res) => {
-    const errors = validationResult(req);
-    const {author, message} = req.body;
+router.post('/', async (req, res) => {
+  const {author, message} = req.body;
+  const newMessage = new Message({author, message});
 
-    if (errors.isEmpty()) {
-      await Message.create({author, message});
-      res.redirect('/');
-    } else {
-      res.status(400);
+  newMessage.validateSync();
 
-      res.render('index', {
-        errors: errors.mapped(),
-        messages: await Message.find({}),
-      });
-    }
+  if (newMessage.errors) {
+    res.status(400);
+
+    res.render('index', {
+      newMessage: newMessage,
+      messages: await Message.find({}),
+    });
+  } else {
+    await newMessage.save();
+    res.redirect('/');
   }
-);
+});
 
 module.exports = router;

--- a/test/models/message-test.js
+++ b/test/models/message-test.js
@@ -1,0 +1,50 @@
+const Message = require('../../models/message');
+const {assert} = require('chai');
+const database = require('../../database');
+
+describe('Message', () => {
+  beforeEach(async () => {
+    const db = database.connection.db;
+    if (db) {
+      await db.dropDatabase();
+    }
+  });
+
+  describe('#author', () => {
+    it('is a String', () => {
+      const authorAsAnInt = 1;
+
+      const message = new Message({ author: authorAsAnInt });
+
+      assert.strictEqual(message.author, authorAsAnInt.toString());
+    });
+
+    it('is required', () => {
+      const message = new Message({ author: null })
+
+      message.validateSync();
+
+      const errors = message.errors;
+      assert.equal(errors.author.message, 'Path `author` is required.');
+    });
+  });
+
+  describe('#message', () => {
+    it('is a String', () => {
+      const messageAsAnInt = 1;
+
+      const message = new Message({ message: messageAsAnInt });
+
+      assert.strictEqual(message.message, messageAsAnInt.toString());
+    });
+
+    it('is required', () => {
+      const message = new Message({ message: null })
+
+      message.validateSync();
+
+      const errors = message.errors;
+      assert.equal(errors.message.message, 'Path `message` is required.');
+    });
+  });
+});

--- a/test/routes/messages-test.js
+++ b/test/routes/messages-test.js
@@ -62,7 +62,7 @@ describe('/messages', () => {
           .send({message});
 
         assert.equal(response.status, 400);
-        assert.include(parseTextFromHTML(response.text, '#message-form'), 'Invalid value');
+        assert.include(parseTextFromHTML(response.text, '#message-form'), 'required');
         assert.equal((await Message.find({})).length, 0, 'did not save the Message');
       });
     });
@@ -76,7 +76,7 @@ describe('/messages', () => {
           .send({author});
 
         assert.equal(response.status, 400);
-        assert.include(parseTextFromHTML(response.text, '#message-form'), 'Invalid value');
+        assert.include(parseTextFromHTML(response.text, '#message-form'), 'required');
         assert.equal((await Message.find({})).length, 0, 'did not save the Message');
       });
     });

--- a/views/index.handlebars
+++ b/views/index.handlebars
@@ -7,15 +7,15 @@
 
 <form id="message-form" action="/messages" method="post" >
   <label for="author">Your name:</label>
-  <input type="text" id="author" name="author">
-  {{#with (lookup errors "author") as |error|}}
-    <span class="error">{{error.msg}}</span>
+  <input type="text" id="author" name="author" value="{{newMessage.author}}">
+  {{#with newMessage.errors.author as |error|}}
+    <span class="error">{{error.message}}</span>
   {{/with}}
 
   <label for="message">Your message:</label>
-  <textarea id="message" name="message"></textarea>
-  {{#with (lookup errors "message") as |error|}}
-    <span class="error">{{error.msg}}</span>
+  <textarea id="message" name="message">{{newMessage.message}}</textarea>
+  {{#with newMessage.errors.message as |error|}}
+    <span class="error">{{error.message}}</span>
   {{/with}}
 
   <input type="submit">


### PR DESCRIPTION
Asserting the validity of a model from our Database's perspective is a
Model-level concern.

This commit removes `express-validator` in favor of Mongoose.

As a result, this commit also changes how our templates access the
resulting Error messages created by Mongoose.

The supporting changes were test-driven by adding tests at the Model
layer, as well as changing some expectations around Error message copy.

Unfortunately, Mongoose doesn't provide great user-facing error
messages. They can probably be overridden by Mongoose configuration,
but that seems out of scope for this dummy application.