### PR TITLE
Remove `partial` template declarations

### DIFF
--- a/test/features/user-visits-root-test.js
+++ b/test/features/user-visits-root-test.js
@@ -9,9 +9,9 @@ describe('User visits root', () => {
       const message = 'Why test?';
 
       browser.url('/');
-      browser.setValue('input[name=author]', author);
-      browser.setValue('input[name=message]', message);
-      browser.click('input[type=submit]');
+      browser.setValue('[name=author]', author);
+      browser.setValue('[name=message]', message);
+      browser.click('[type=submit]');
 
       assert.include(messagesText(), message);
       assert.include(messagesText(), author);

--- a/views/index.handlebars
+++ b/views/index.handlebars
@@ -7,10 +7,16 @@
 
 <form id="message-form" action="/messages" method="post" >
   <label for="author">Your name:</label>
-  {{> input-with-errors errors=errors name="author"}}
+  <input type="text" id="author" name="author">
+  {{#with (lookup errors "author") as |error|}}
+    <span class="error">{{error.msg}}</span>
+  {{/with}}
 
   <label for="message">Your message:</label>
-  {{> input-with-errors errors=errors name="message"}}
+  <textarea id="message" name="message"></textarea>
+  {{#with (lookup errors "message") as |error|}}
+    <span class="error">{{error.msg}}</span>
+  {{/with}}
 
   <input type="submit">
 </form>

--- a/views/partials/input-with-errors.handlebars
+++ b/views/partials/input-with-errors.handlebars
@@ -1,4 +1,0 @@
-<input type="text" id="{{name}}" name="{{name}}">
-{{#with (lookup errors name) as |error|}}
-  <span class="error">{{error.msg}}</span>
-{{/with}}


### PR DESCRIPTION
Since we aren't planning on explicitly going into depth on how to
extract and use template partials, this commit uses in-line templating
instead.

This approach relies on duplication, but is much easier to understand
and presents fewer barriers to learners.