### PR TITLE
Standardize Setup and Cleanup

### DIFF
--- a/app.js
+++ b/app.js
@@ -6,7 +6,6 @@ const logger = require('morgan');
 const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
 
-const database = require('./database');
 const index = require('./routes/index');
 const messages = require('./routes/messages');
 

--- a/bin/www
+++ b/bin/www
@@ -7,6 +7,7 @@
 const app = require('../app');
 const debug = require('debug')('calculator-js:server');
 const http = require('http');
+const {mongoose, databaseUrl, options} = require('../database');
 
 /**
  * Get port from environment and store in Express.
@@ -25,7 +26,9 @@ const server = http.createServer(app);
  * Listen on provided port, on all network interfaces.
  */
 
-server.listen(port);
+mongoose.connect(databaseUrl, options).then(() => {
+  server.listen(port);
+});
 server.on('error', onError);
 server.on('listening', onListening);
 

--- a/database.js
+++ b/database.js
@@ -3,9 +3,12 @@ mongoose.Promise = global.Promise;
 
 const env = process.env.NODE_ENV || 'development';
 const databaseUrl = process.env.DATABASE_URL || `mongodb://localhost/why-test_${env}`;
-
-mongoose.connect(databaseUrl, {
+const options= {
   useMongoClient: true,
-});
+};
 
-module.exports = mongoose;
+module.exports = {
+  mongoose,
+  databaseUrl,
+  options,
+};

--- a/test/models/message-test.js
+++ b/test/models/message-test.js
@@ -1,13 +1,15 @@
 const Message = require('../../models/message');
 const {assert} = require('chai');
-const database = require('../../database');
+const {mongoose, databaseUrl, options} = require('../../database');
 
 describe('Message', () => {
   beforeEach(async () => {
-    const db = database.connection.db;
-    if (db) {
-      await db.dropDatabase();
-    }
+    await mongoose.connect(databaseUrl, options);
+    await mongoose.connection.db.dropDatabase();
+  });
+
+  afterEach(async () => {
+    await mongoose.disconnect();
   });
 
   describe('#author', () => {

--- a/test/routes/messages-test.js
+++ b/test/routes/messages-test.js
@@ -3,7 +3,7 @@ const request = require('supertest');
 const {jsdom} = require('jsdom');
 
 const app = require('../../app');
-const database = require('../../database');
+const {mongoose, databaseUrl, options} = require('../../database');
 const Message = require('../../models/message');
 
 const PORT = process.env.EXPRESS_PORT || 3000;
@@ -15,16 +15,14 @@ const parseTextFromHTML = (htmlAsString, selector) => {
 describe('/messages', () => {
   let server;
 
-  beforeEach('Start server', (done) => {
-    server = app.listen(PORT, done);
+  beforeEach('Start server', async () => {
+    await mongoose.connect(databaseUrl, options);
+    await mongoose.connection.db.dropDatabase();
+    server = await app.listen(PORT);
   });
 
-  afterEach('Drop database', (done) => {
-    database.connection.db.dropDatabase(done);
-  });
-
-  afterEach('Shutdown server', (done) => {
-    server.close(done);
+  afterEach('Shutdown server', async () => {
+    await server.close();
   });
 
   describe('POST', () => {

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -1,6 +1,6 @@
 const app = require('./app');
 const port = process.env.PORT || 3000;
-const database = require("./database");
+const {mongoose, databaseUrl, options} = require('./database');
 
 let expressServer;
 
@@ -24,12 +24,14 @@ exports.config = {
   }],
   services: ['selenium-standalone'],
 
-  async onPrepare() {
+  async beforeTest() {
+    await mongoose.connect(databaseUrl, options);
+    await mongoose.connection.db.dropDatabase();
     expressServer = app.listen(port);
   },
-  async onComplete() {
-    await expressServer.close();
-    await database.connection.db.dropDatabase();
-    await database.disconnect();
+
+  async afterTest() {
+    await mongoose.disconnect();
+    expressServer.close();
   },
 };


### PR DESCRIPTION
This commit:

* restructures `database.js` so that it has no side-effects when
  required
* asynchronously connect to the database _before_ starting the Express
  server, when applicable
* Drop the database before _each_ test

Prior to this commit, WebDriver tests were improperly configured to only
cleanup the database once-per-suite, instead of once-per-test.