### PR TITLE
streamlines server + server tests

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,9 +1,7 @@
 const express = require('express');
 const expressHandlebars = require('express-handlebars');
 const path = require('path');
-const favicon = require('serve-favicon');
 const logger = require('morgan');
-const cookieParser = require('cookie-parser');
 const bodyParser = require('body-parser');
 
 const index = require('./routes/index');
@@ -16,12 +14,8 @@ app.engine('handlebars', expressHandlebars({defaultLayout: 'app'}));
 app.set('views', path.join(__dirname, 'views'));
 app.set('view engine', 'handlebars');
 
-// Uncomment after placing your favicon in /public
-// app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
 app.use(logger('dev'));
-app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({extended: false}));
-app.use(cookieParser());
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/', index);
@@ -35,7 +29,7 @@ app.use(function(req, res, next) {
 });
 
 // Error handler
-app.use((err, req, res) => {
+app.use((err, req, res, next) => {
   // Set locals, only providing error in development
   res.locals.message = err.message;
   res.locals.error = req.app.get('env') === 'development' ? err : {};

--- a/bin/mocha-test
+++ b/bin/mocha-test
@@ -2,6 +2,7 @@
 
 set -e
 
+export NODE_ENV=test
 tests_that_are_not_features="$(ls test/**/*-test.js | grep -v features)"
 
 ./node_modules/.bin/mocha ${tests_that_are_not_features}

--- a/bin/wdio-test
+++ b/bin/wdio-test
@@ -2,4 +2,5 @@
 
 set -e
 
+export NODE_ENV=test
 ./node_modules/webdriverio/bin/wdio wdio.conf.js

--- a/bin/www
+++ b/bin/www
@@ -5,7 +5,6 @@
  */
 
 const app = require('../app');
-const debug = require('debug')('calculator-js:server');
 const http = require('http');
 const {mongoose, databaseUrl, options} = require('../database');
 
@@ -13,7 +12,7 @@ const {mongoose, databaseUrl, options} = require('../database');
  * Get port from environment and store in Express.
  */
 
-const port = normalizePort(process.env.PORT || '3000');
+const port = normalizePort(process.env.PORT || require('../server.config').development.port);
 app.set('port', port);
 
 /**
@@ -89,5 +88,5 @@ function onListening() {
   const bind = typeof addr === 'string'
     ? 'pipe ' + addr
     : 'port ' + addr.port;
-  debug('Listening on ' + bind);
+  console.log('Listening on ' + bind);
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "debug": "node --inspect ./bin/www",
     "test": "bin/mocha-test && bin/wdio-test"
   },
   "dependencies": {

--- a/server.config.js
+++ b/server.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  development: {
+    port: 4001,
+  },
+  test: {
+    port: 8001,
+  },
+};

--- a/test/routes/messages-test.js
+++ b/test/routes/messages-test.js
@@ -5,8 +5,9 @@ const {jsdom} = require('jsdom');
 const app = require('../../app');
 const {mongoose, databaseUrl, options} = require('../../database');
 const Message = require('../../models/message');
+const {port} = require('../../server.config').test;
 
-const PORT = process.env.EXPRESS_PORT || 3000;
+const PORT = process.env.PORT || port;
 
 const parseTextFromHTML = (htmlAsString, selector) => {
   return jsdom(htmlAsString).querySelector(selector).textContent;
@@ -21,7 +22,8 @@ describe('/messages', () => {
     server = await app.listen(PORT);
   });
 
-  afterEach('Shutdown server', async () => {
+  afterEach('Drop database and close server', async () => {
+    await mongoose.disconnect();
     await server.close();
   });
 
@@ -31,9 +33,10 @@ describe('/messages', () => {
         const author = 'Inquisitive User';
         const message = 'Why Test?';
 
-        const response = await request(server).
-          post('/messages').
-          send({author, message});
+        const response = await request(server)
+          .post('/messages')
+          .type('form')
+          .send({author, message});
 
         assert.ok(await Message.findOne({message, author}), 'Creates a Message record');
       });
@@ -42,9 +45,10 @@ describe('/messages', () => {
         const author = 'Inquisitive User';
         const message = 'Why Test?';
 
-        const response = await request(server).
-          post('/messages').
-          send({author, message});
+        const response = await request(server)
+          .post('/messages')
+          .type('form')
+          .send({author, message});
 
         assert.equal(response.status, 302);
         assert.equal(response.headers.location, '/');

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -1,5 +1,5 @@
 const app = require('./app');
-const port = process.env.PORT || 3000;
+const port = process.env.PORT || require('./server.config').test.port;
 const {mongoose, databaseUrl, options} = require('./database');
 
 let expressServer;


### PR DESCRIPTION
- abstracts PORT and TESTING_PORT to a config object
- removes unnecessary server code + modules
- ensures that supertest tests are sending `application/x-www-form-urlencoded` data with `.type('form')`
- sets NODE_ENV on test scripts so that test and production databases do not interact